### PR TITLE
PILOT-1166: Implement Avro schema & dead letter queue

### DIFF
--- a/MetadataConsumer.py
+++ b/MetadataConsumer.py
@@ -62,8 +62,8 @@ class MetadataConsumer:
         es_item.owner = message['owner']
         es_item.container_code = message['container_code']
         es_item.container_type = message['container_type']
-        es_item.created_time = convert_timestamp(message['created_time'])
-        es_item.last_updated_time = convert_timestamp(message['last_updated_time'])
+        es_item.created_time = message['created_time']
+        es_item.last_updated_time = message['last_updated_time']
         es_item.items_set = True
         if es_item.is_complete():
             self.pending_items.pop(item_id)

--- a/kafka_schema/metadata.items.activity.avsc
+++ b/kafka_schema/metadata.items.activity.avsc
@@ -6,8 +6,8 @@
     {
       "name": "item_id",
       "type": {
-		  "type": "string",
-		  "logicalType": "uuid"
+	"type": "string",
+	"logicalType": "uuid"
       }
     }, {
       "name": "item_name",
@@ -39,18 +39,18 @@
     }, {
       "name": "activity_time",
       "type": {
-		  "type": "long",
-		  "logicalType": "timestamp-millis"
+	"type": "long",
+	"logicalType": "timestamp-millis"
       }
     }, {
       "name": "changes",
       "type": {
-		  "type": "array",
-		  "items": {
-			  "type": "map",
-			  "values": "string"
-		  }
-	  }
+	"type": "array",
+	"items": {
+		"type": "map",
+		"values": "string"
+	}
+      }
     }
   ]
 }

--- a/kafka_schema/metadata.items.activity.avsc
+++ b/kafka_schema/metadata.items.activity.avsc
@@ -1,0 +1,56 @@
+{
+  "type": "record",
+  "name": "Activity",
+  "namespace": "metadata.items",
+  "fields": [
+    {
+      "name": "item_id",
+      "type": {
+		  "type": "string",
+		  "logicalType": "uuid"
+      }
+    }, {
+      "name": "item_name",
+      "type": "string"
+    }, {
+      "name": "item_type",
+      "type": "string"
+    }, {
+      "name": "item_parent_path",
+      "type": "string"
+    }, {
+      "name": "container_code",
+      "type": "string"
+    }, {
+      "name": "container_type",
+      "type": "string"
+    }, {
+      "name": "zone",
+      "type": "int"
+    }, {
+      "name": "user",
+      "type": "string"
+    }, {
+      "name": "imported_from",
+      "type": ["string", "null"]
+    }, {
+      "name": "activity_type",
+      "type": "string"
+    }, {
+      "name": "activity_time",
+      "type": {
+		  "type": "long",
+		  "logicalType": "timestamp-millis"
+      }
+    }, {
+      "name": "changes",
+      "type": {
+		  "type": "array",
+		  "items": {
+			  "type": "map",
+			  "values": "string"
+		  }
+	  }
+    }
+  ]
+}

--- a/kafka_schema/metadata.metadata.extended.avsc
+++ b/kafka_schema/metadata.metadata.extended.avsc
@@ -1,0 +1,44 @@
+{
+  "type": "record",
+  "name": "Extended",
+  "namespace": "metadata.items",
+  "fields": [
+    {
+      "name": "item_id",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
+  	}, {
+      "name": "extra",
+      "type": {
+        "type": "record",
+        "name": "extra",
+        "fields": [
+          {
+          "name": "tags",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
+      }, {
+          "name": "system_tags",
+          "type": {
+            "type": "array",
+            "items": "string"
+        }
+      }, {
+          "name": "attributes",
+          "type": {
+            "type": "map",
+            "name": "attributes",
+            "values": [
+              {
+                "type": "map",
+                "values": "string"
+          }]
+        }
+      }]
+    }
+  } ]
+}

--- a/kafka_schema/metadata.metadata.items.avsc
+++ b/kafka_schema/metadata.metadata.items.avsc
@@ -1,0 +1,59 @@
+{
+  "type": "record",
+  "name": "Items",
+  "namespace": "metadata.items",
+  "fields": [
+    {
+      "name": "id",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
+    }, {
+      "name": "parent",
+      "type": ["string", "null"]
+    }, {
+      "name": "parent_path",
+      "type": ["string", "null"]
+    }, {
+      "name": "restore_path",
+      "type": ["string", "null"]
+    }, {
+      "name": "archived",
+      "type": "boolean"
+    }, {
+      "name": "type",
+      "type": "string"
+    }, {
+      "name": "zone",
+      "type": "int"
+    }, {
+      "name": "name",
+      "type": "string"
+    }, {
+      "name": "size",
+      "type": "int"
+    }, {
+      "name": "owner",
+      "type": "string"
+    }, {
+      "name": "container_code",
+      "type": "string"
+    }, {
+      "name": "container_type",
+      "type": "string"
+    }, {
+      "name": "created_time",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      }
+    }, {
+      "name": "last_updated_time",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      }
+    }
+  ]
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,21 @@
 [[package]]
+name = "avro"
+version = "1.11.0"
+description = "Avro is a serialization and RPC framework."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+snappy = ["python-snappy"]
+zstandard = ["zstandard"]
+
+[[package]]
 name = "certifi"
-version = "2022.5.18.1"
+version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -50,6 +65,14 @@ python-versions = ">=3.5"
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "urllib3"
 version = "1.26.9"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -65,12 +88,15 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "8d618108fcf9f7b0d9e374287338c21ec05b84318c6c6f0dd316c1ab1cf81df4"
+content-hash = "f5ee81aa475bd72674242e5da26320b46c74d2b635ce4984949aa568301d5587"
 
 [metadata.files]
+avro = [
+    {file = "avro-1.11.0.tar.gz", hash = "sha256:1206365cc30ad561493f735329857dd078533459cee4e928aec2505f341ce445"},
+]
 certifi = [
-    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
-    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
 ]
 elasticsearch = [
     {file = "elasticsearch-7.8.1-py2.py3-none-any.whl", hash = "sha256:2ffbd746fc7d2db08e5ede29c822483705f29c4bf43b0875c238637d5d843d44"},
@@ -82,6 +108,10 @@ kafka-python3 = [
 python-dotenv = [
     {file = "python-dotenv-0.20.0.tar.gz", hash = "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f"},
     {file = "python_dotenv-0.20.0-py3-none-any.whl", hash = "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.6"
 kafka-python3 = "3.0.0"
 elasticsearch = "7.8.1"
 python-dotenv = "0.20.0"
+avro = "^1.11.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,6 @@ from avro import schema
 from avro.io import BinaryDecoder
 from avro.io import DatumReader
 from avro.io import validate
-from kafka import KafkaProducer
 
 from config import KAKFA_SERVICE
 
@@ -47,11 +46,6 @@ def decode_path_from_ltree(encoded_path: str) -> str:
 def convert_timestamp(timestamp: datetime) -> str:
     converted = str(int(datetime.timestamp(timestamp)) * 1000)
     return converted
-
-
-def publish_dlq(message: bytes):
-    producer = KafkaProducer(bootstrap_servers=[KAKFA_SERVICE])
-    producer.send('metadata.dlq', message)
 
 
 def decode_message(message: bytes, topic: str) -> dict:


### PR DESCRIPTION
## Summary

- Added Avro schema deserialization for item activity messages consumed. Respective schemas also added under: `kafka_schema`. 
- Kafka postgres connector does not currently have an avro schema implemented for item and extended messages (temporarily). This will take further developmental efforts and research. Therefore, these messages are not avro encoded.
- Implemented producer to send messages that fail decoding process to dead letter queue (including messages that are not Avro encoded).

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1166

## Type of Change

_Please delete options that are not relevant._

- [X] New feature (non-breaking change which adds functionality)
- [X] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

_(Additional instructions for how to run tests or validate functionality if not covered by unit tests)_
