### PR TITLE
PILOT-1300: Add null type to item_id in items activity schema

### DIFF
--- a/kafka_schema/metadata.items.activity.avsc
+++ b/kafka_schema/metadata.items.activity.avsc
@@ -5,10 +5,10 @@
   "fields": [
     {
       "name": "item_id",
-      "type": {
+      "type": ["null", {
 	"type": "string",
 	"logicalType": "uuid"
-      }
+      }]
     }, {
       "name": "item_name",
       "type": "string"


### PR DESCRIPTION
## Summary

- Added `null` type to item_id field in `metadata.items.activity` schema to support download action of multiple files into a single zip (this would result in the absence of an item_id for the activity logs).

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1300

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions
